### PR TITLE
Fix: Issue #15 - Recent change to t! macro unnecessarily breaks v0.3 code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [0.4.1]
+## [0.4.2]
+
+### Fixed
+
+- [Issue #15](https://github.com/dioxus-community/dioxus-i18n/issues/15) Recent change to t! macro unnecessarily breaks v0.3 code.
+
+## [0.4.1] 2025-02-02
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 - New methods (`I18nConfig::with_auto_locales`) to determine supported locales from deep search for translation files.
 
 - New methods returning `Result<_, Error>` rather than `panic!`, such that:
-
   | __`panic!` version__                    | __`Result<_, Error>` vesion__            |
   |--------------------------------  -------|------  ----------------------------------|
   | `LocaleResource::to_resource_string`    | `LocaleResource::try_to_resource_string` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - [Issue #15](https://github.com/dioxus-community/dioxus-i18n/issues/15) Recent change to t! macro unnecessarily breaks v0.3 code.
 
+### Amended
+
+- t! macro amended to use unwrap_or_else rather than panic!.
+
+- Error messages made consistant across all macros.
+
 ## [0.4.1] 2025-02-02
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-i18n"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Marc Espín <mespinsanz@gmail.com>"]
 description = "i18n integration for Dioxus apps based on Fluent Project."

--- a/src/i18n_macro.rs
+++ b/src/i18n_macro.rs
@@ -38,11 +38,9 @@ macro_rules! te {
         }
     };
 
-    ($id:expr ) => {
-        {
+    ($id:expr ) => {{
             dioxus_i18n::prelude::i18n().try_translate($id)
-        }
-    };
+    }};
 }
 
 /// Translate message from key, panic! if id not found...
@@ -66,11 +64,11 @@ macro_rules! te {
 #[macro_export]
 macro_rules! t {
     ($id:expr, $( $name:ident : $value:expr ),* ) => {
-        dioxus_i18n::te!($id, $( $name : $value ),*).expect(&format!("message-id: {} should be translated", $id))
+        dioxus_i18n::te!($id, $( $name : $value ),*).unwrap_or_else(|e| panic!("{}", e.to_string()))
     };
 
     ($id:expr ) => {{
-        dioxus_i18n::te!($id).expect(&format!("message-id: {} should be translated", $id))
+        dioxus_i18n::te!($id).unwrap_or_else(|e| panic!("{}", e.to_string()))
     }};
 }
 
@@ -94,10 +92,10 @@ macro_rules! t {
 #[macro_export]
 macro_rules! tid {
     ($id:expr, $( $name:ident : $value:expr ),* ) => {
-        dioxus_i18n::te!($id, $( $name : $value ),*).unwrap_or(format!("message-id: {:?} should be translated", $id))
+        dioxus_i18n::te!($id, $( $name : $value ),*).unwrap_or_else(|e| e.to_string())
     };
 
     ($id:expr ) => {{
-        dioxus_i18n::te!($id).unwrap_or(format!("message-id: {:?} should be translated", $id))
+        dioxus_i18n::te!($id).unwrap_or_else(|e| e.to_string())
     }};
 }

--- a/src/i18n_macro.rs
+++ b/src/i18n_macro.rs
@@ -66,11 +66,11 @@ macro_rules! te {
 #[macro_export]
 macro_rules! t {
     ($id:expr, $( $name:ident : $value:expr ),* ) => {
-        dioxus_i18n::te!($id, $( $name : $value ),*).expect(concat!("message-id: ", $id, " should be translated"))
+        dioxus_i18n::te!($id, $( $name : $value ),*).expect(&format!("message-id: {} should be translated", $id))
     };
 
     ($id:expr ) => {{
-        dioxus_i18n::te!($id).expect(concat!("message-id: ", $id, " should be translated"))
+        dioxus_i18n::te!($id).expect(&format!("message-id: {} should be translated", $id))
     }};
 }
 

--- a/tests/data/i18n/en.ftl
+++ b/tests/data/i18n/en.ftl
@@ -1,1 +1,2 @@
 hello = Hello, {$name}!
+simple = Hello, Zaphod!

--- a/tests/defects_spec.rs
+++ b/tests/defects_spec.rs
@@ -1,0 +1,44 @@
+mod common;
+use common::*;
+
+use dioxus_i18n::{
+    prelude::{use_init_i18n, I18n, I18nConfig},
+    t,
+};
+use unic_langid::{langid, LanguageIdentifier};
+
+#[test]
+fn issue_15_recent_change_to_t_macro_unnecessarily_breaks_v0_3_code_test_attr() {
+    test_hook(i18n_from_static, |_, proxy| {
+        let panic = std::panic::catch_unwind(|| {
+            let name = "World";
+            t!(&format!("hello"), name: name)
+        });
+        proxy.assert(panic.is_ok(), true, "translate_from_static_source");
+        proxy.assert(
+            panic.ok().unwrap(),
+            "Hello, \u{2068}World\u{2069}!".to_string(),
+            "translate_from_static_source",
+        );
+    });
+}
+
+#[test]
+fn issue_15_recent_change_to_t_macro_unnecessarily_breaks_v0_3_code_test_no_attr() {
+    test_hook(i18n_from_static, |_, proxy| {
+        let panic = std::panic::catch_unwind(|| t!(&format!("simple")));
+        proxy.assert(panic.is_ok(), true, "translate_from_static_source");
+        proxy.assert(
+            panic.ok().unwrap(),
+            "Hello, Zaphod!".to_string(),
+            "translate_from_static_source",
+        );
+    });
+}
+
+const EN: LanguageIdentifier = langid!("en");
+
+fn i18n_from_static() -> I18n {
+    let config = I18nConfig::new(EN).with_locale((EN, include_str!("./data/i18n/en.ftl")));
+    use_init_i18n(|| config)
+}

--- a/tests/translations_spec.rs
+++ b/tests/translations_spec.rs
@@ -80,7 +80,7 @@ fn failed_to_translate_with_invalid_key_as_id() {
         );
         proxy.assert(
             panic.ok().unwrap(),
-            "message-id: \"invalid\" should be translated".to_string(),
+            "message id not found for key: 'invalid'".to_string(),
             "failed_to_translate_with_invalid_key_as_id",
         );
     });
@@ -97,7 +97,7 @@ fn failed_to_translate_with_invalid_key_with_args_as_id() {
         );
         proxy.assert(
             panic.ok().unwrap(),
-            "message-id: \"invalid\" should be translated".to_string(),
+            "message id not found for key: 'invalid'".to_string(),
             "failed_to_translate_with_invalid_key_with_args_as_id",
         );
     });


### PR DESCRIPTION
Use format! rather than concat! so end user not forced to use literal in `t!` macro.