### PR TITLE
Bump diouxs version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "./README.md"
 categories = ["accessibility", "gui", "localization", "internationalization"]
 
 [dependencies]
-dioxus = { version = "0.7.0-rc.1", default-features = false, features = [
+dioxus = { version = "0.7.0-rc.2", default-features = false, features = [
     "hooks",
     "macro",
     "signals",
@@ -23,7 +23,7 @@ unic-langid = { version = "0.9", features = ["macros"] }
 walkdir = "2.5.0"
 
 [dev-dependencies]
-dioxus = { version = "0.7.0-rc.1", features = ["desktop"] }
+dioxus = { version = "0.7.0-rc.2", features = ["desktop"] }
 freya = "0.3"
 futures = "0.3.31"
 pretty_assertions = "1.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "./README.md"
 categories = ["accessibility", "gui", "localization", "internationalization"]
 
 [dependencies]
-dioxus-lib = { version = "0.7.0-alpha.3", default-features = false, features = [
+dioxus = { git = "https://github.com/DioxusLabs/dioxus", default-features = false, features = [
     "hooks",
     "macro",
     "signals",
@@ -23,7 +23,7 @@ unic-langid = { version = "0.9", features = ["macros"] }
 walkdir = "2.5.0"
 
 [dev-dependencies]
-dioxus = { version = "0.7.0-alpha.3", features = ["desktop"] }
+dioxus = { git = "https://github.com/DioxusLabs/dioxus", features = ["desktop"] }
 freya = "0.3"
 futures = "0.3.31"
 pretty_assertions = "1.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "./README.md"
 categories = ["accessibility", "gui", "localization", "internationalization"]
 
 [dependencies]
-dioxus = { git = "https://github.com/DioxusLabs/dioxus", default-features = false, features = [
+dioxus = { version = "0.7.0-rc.1", default-features = false, features = [
     "hooks",
     "macro",
     "signals",
@@ -23,7 +23,7 @@ unic-langid = { version = "0.9", features = ["macros"] }
 walkdir = "2.5.0"
 
 [dev-dependencies]
-dioxus = { git = "https://github.com/DioxusLabs/dioxus", features = ["desktop"] }
+dioxus = { version = "0.7.0-rc.1", features = ["desktop"] }
 freya = "0.3"
 futures = "0.3.31"
 pretty_assertions = "1.4.1"

--- a/src/use_i18n.rs
+++ b/src/use_i18n.rs
@@ -1,6 +1,6 @@
 use super::error::Error;
 
-use dioxus_lib::prelude::*;
+use dioxus::prelude::*;
 use fluent::{FluentArgs, FluentBundle, FluentResource};
 use unic_langid::LanguageIdentifier;
 

--- a/tests/common/test_hook.rs
+++ b/tests/common/test_hook.rs
@@ -59,8 +59,6 @@ pub(crate) fn test_hook<V: 'static>(
     while vdom.wait_for_work().now_or_never().is_some() {
         vdom.render_immediate(&mut NoOpMutations);
     }
-
-    vdom.in_runtime(|| ScopeId::ROOT.in_runtime(|| {}))
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
The git version of dioxus has some breaking changes, this PR updates i18n with those changes. I needed this for the playground/component library and will try to keep it updated as more breaking changes come in