### PR TITLE
feat: update to dioxus 0.7.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.5.0-rc.1]
+
+### Changed
+- **BREAKING**: Updated dependencies to support Dioxus 0.7.0-rc.1
+- Updated from `dioxus-lib` to `dioxus` package name following Dioxus API changes
+- Fixed test compatibility with new ScopeId API (removed deprecated `in_runtime()` method)
+
+### Note
+This is a breaking change that requires users to update to Dioxus 0.7.0-rc.1 or later. While the public API of dioxus-i18n remains the same, the underlying dependency changes make this incompatible with previous Dioxus versions.
+
 ## [0.4.3]
 
 - [Issue #19](https://github.com/dioxus-community/dioxus-i18n/issues/19) Enable use of "message-id.attribute-id"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-i18n"
-version = "0.4.3"
+version = "0.5.0-rc.1"
 edition = "2021"
 authors = ["Marc Espín <mespinsanz@gmail.com>"]
 description = "i18n integration for Dioxus apps based on Fluent Project."
@@ -10,7 +10,7 @@ readme = "./README.md"
 categories = ["accessibility", "gui", "localization", "internationalization"]
 
 [dependencies]
-dioxus-lib = { version = "0.7.0-alpha.3", default-features = false, features = [
+dioxus = { git = "https://github.com/DioxusLabs/dioxus", tag = "v0.7.0-rc.1", default-features = false, features = [
     "hooks",
     "macro",
     "signals",
@@ -23,7 +23,7 @@ unic-langid = { version = "0.9", features = ["macros"] }
 walkdir = "2.5.0"
 
 [dev-dependencies]
-dioxus = { version = "0.7.0-alpha.3", features = ["desktop"] }
+dioxus = { git = "https://github.com/DioxusLabs/dioxus", tag = "v0.7.0-rc.1", features = ["desktop"] }
 freya = "0.3"
 futures = "0.3.31"
 pretty_assertions = "1.4.1"

--- a/src/use_i18n.rs
+++ b/src/use_i18n.rs
@@ -1,6 +1,6 @@
 use super::error::Error;
 
-use dioxus_lib::prelude::*;
+use dioxus::prelude::*;
 use fluent::{FluentArgs, FluentBundle, FluentResource};
 use unic_langid::LanguageIdentifier;
 

--- a/tests/common/test_hook.rs
+++ b/tests/common/test_hook.rs
@@ -60,7 +60,7 @@ pub(crate) fn test_hook<V: 'static>(
         vdom.render_immediate(&mut NoOpMutations);
     }
 
-    vdom.in_runtime(|| ScopeId::ROOT.in_runtime(|| {}))
+    vdom.in_runtime(|| {})
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
BREAKING CHANGE: Update dependencies from dioxus-lib 0.7.0-alpha.3 to dioxus 0.7.0-rc.1
- Changed package name from dioxus-lib to dioxus following upstream API changes
- Fixed ScopeId API compatibility (removed deprecated in_runtime method)
- All tests passing with new version
- Bumped version to 0.5.0-rc.1 to track Dioxus RC compatibility

This update maintains the same public API but requires Dioxus 0.7.0-rc.1+.